### PR TITLE
fix: Initialize i18next to resolve rendering issues

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,4 +1,5 @@
-﻿import React from 'react';
+import './i18n';
+import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter as Router } from 'react-router-dom';
 import App from './App';


### PR DESCRIPTION
This commit fixes a critical rendering issue where CSS styles and translations were not being applied. The root cause was the missing initialization of the i18next instance, which was causing a `NO_I18NEXT_INSTANCE` warning in the console.

By importing the i18n configuration into the main application entry point (`src/main.jsx`), we ensure that i18next is properly configured before any components attempt to use it. This resolves the warning and allows the application to render correctly with all styles and translated text.