### PR TITLE
fix(build): Use relative paths for assets

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -2,11 +2,11 @@
 <html lang="cs">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AI Sensei</title>
-    <script type="module" crossorigin src="/assets/index-BSKAbKWa.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-CP668zLn.css">
+    <script type="module" crossorigin src="./assets/index-BSKAbKWa.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-CP668zLn.css">
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="cs">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AI Sensei</title>
   </head>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import { fileURLToPath, URL } from 'url'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
The application was failing to load CSS and other static assets because the build process generated absolute paths (e.g., `/assets/index.css`). When deployed, these paths could not be resolved, leading to 404 errors.

This commit fixes the issue by:
1. Setting `base: ''` in `vite.config.js` to ensure all generated asset paths in `index.html` are relative.
2. Updating the favicon link in the root `index.html` to use a relative path.

These changes ensure that the application can correctly locate its assets regardless of the deployment path.